### PR TITLE
Add `isLight: true` class property to Light.d.ts

### DIFF
--- a/src/lights/Light.d.ts
+++ b/src/lights/Light.d.ts
@@ -12,6 +12,7 @@ export class Light extends Object3D {
 
   color: Color;
   intensity: number;
+	isLight: true;
   receiveShadow: boolean;
   shadow: LightShadow;
   /**


### PR DESCRIPTION
## Description

This PR adds the instance property `isLight: true` to the TypeScript type definitions for the `THREE.Light` class.

## Use Case

I have some code in a project which uses `THREE.Scene.traverse()` to determine if a given scene (loaded from glTF, in this case) contains light objects. See this Gist for the code: https://gist.github.com/kohlmannj/d64df72eb8d7309ff7120bc9743e95dd

Since the type definition for `THREE.Light` doesn’t define the `isLight` property, this TS code has an error:
```ts
scene.traverse((object: THREE.Object3D | THREE.Light) => {
  if ('isLight' in object) {
    console.log('Found light in scene', object);
    // This line has a TypeScript error in Three.js r103:
    object.isLight; // ERROR: Property 'isLight' does not exist on type 'never’. ts(2339)
  }
});
```

That is, I’m trying to use _type narrowing_ to write a type-safe check that a given object is indeed a `Light` subclass.

—

The implementation of the `Light` class in Three.js r103 does indeed contain [an `isLight` property](https://github.com/mrdoob/three.js/blob/r103/src/lights/Light.js#L26), and I have previously used a non-type-safe runtime check like `(object as any).isLight` to successfully identify objects that are lights.

Therefore, based on the actual implementation, I believe it’s appropriate to add the property `isLight: true;` to the `THREE.Light` TypeScript definitions.

Thanks and let me know if you have any questions.